### PR TITLE
Provide events when close/dismiss is finished.

### DIFF
--- a/src/app/main/main.component.html
+++ b/src/app/main/main.component.html
@@ -64,7 +64,9 @@
 <!-- Modal events -->
 <ngx-smart-modal #modalEvents [identifier]="'modalEvents'" (onOpen)="log('Modal opened!')"
                  (onClose)="log('Modal closed!')"
-                 (onDismiss)="log('Modal dismissed!')">
+                 (onCloseFinished)="log('Modal close finished!')"
+                 (onDismiss)="log('Modal dismissed!')"
+                 (onDismissFinished)="log('Modal dismiss finished!')">
   <h1>Hi! I'm a modal with events</h1>
   <p>Look at your console, I'm linked to some events (onOpen, onClose and onDismiss)!</p>
 

--- a/src/ngx-smart-modal/src/components/ngx-smart-modal.component.ts
+++ b/src/ngx-smart-modal/src/components/ngx-smart-modal.component.ts
@@ -109,7 +109,9 @@ export class NgxSmartModalComponent implements OnInit, OnDestroy {
   @Output() public visibleChange: EventEmitter<boolean> = new EventEmitter<boolean>();
 
   @Output() public onClose: EventEmitter<any> = new EventEmitter();
+  @Output() public onCloseFinished: EventEmitter<any> = new EventEmitter();
   @Output() public onDismiss: EventEmitter<any> = new EventEmitter();
+  @Output() public onDismissFinished: EventEmitter<any> = new EventEmitter();
   @Output() public onOpen: EventEmitter<any> = new EventEmitter();
   @Output() public onEscape: EventEmitter<any> = new EventEmitter();
 
@@ -156,6 +158,7 @@ export class NgxSmartModalComponent implements OnInit, OnDestroy {
     setTimeout(() => {
       me.overlayVisible = false;
       me.changeDetectorRef.markForCheck();
+      me.onCloseFinished.emit(me);
     }, 150);
   }
 
@@ -171,6 +174,7 @@ export class NgxSmartModalComponent implements OnInit, OnDestroy {
       setTimeout(() => {
         me.overlayVisible = false;
         me.changeDetectorRef.markForCheck();
+        me.onDismissFinished.emit(me);
       }, 150);
     }
   }


### PR DESCRIPTION
Opening a modal directly after closing another one, made my app stuck, because of the overlayVisible attribute, which is set to false inside a 150ms timeout. So I created these 2 new events, which are emitted after the 150ms.