### PR TITLE
create default z-index and check all modals

### DIFF
--- a/src/ngx-smart-modal/src/services/ngx-smart-modal.service.ts
+++ b/src/ngx-smart-modal/src/services/ngx-smart-modal.service.ts
@@ -73,8 +73,8 @@ export class NgxSmartModalService {
    * @returns Returns a higher index from all the existing modal instances.
    */
   public getHigherIndex(): number {
-    const index: number[] = [];
-    const modals: ModalInstance[] = this.getOpenedModals();
+    const index: number[] = [1041];
+    const modals: ModalInstance[] = this.getModalStack();
     modals.forEach((o: ModalInstance) => {
       index.push(o.modal.layerPosition);
     });


### PR DESCRIPTION
I had the problem, that my first opened modal had the `layerPosition=-Infinity` and so calling the `open()` method with `true` to open the modal at the top of the modal stack didn't work. With this fix, the `layerPosition` has a default value as minimum (1042 because of 1041+1).