### PR TITLE
Fix version warning on npm / yarn installation

### DIFF
--- a/src/ngx-smart-modal/package.json
+++ b/src/ngx-smart-modal/package.json
@@ -38,9 +38,9 @@
   ],
   "license": "MIT",
   "peerDependencies": {
-    "@angular/common": ">=2.4.0 <=6.0.0",
-    "@angular/core": ">=2.4.0 <=6.0.0",
-    "@angular/platform-browser": ">=2.4.0 <=6.0.0",
+    "@angular/common": ">=2.4.0",
+    "@angular/core": ">=2.4.0",
+    "@angular/platform-browser": ">=2.4.0",
     "rxjs": ">=5.1.0",
     "zone.js": ">=0.8.0"
   },


### PR DESCRIPTION
Fixes a warning on package install if project's angular version is higher than 6.0.0