### PR TITLE
fix: Fix regression, improve readme, push new version

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,7 +143,7 @@ To change this effect, you can use the `customClass` option (see below) but you 
  - `.nsm-dialog-animation-rtl`: the modal comes with a right-to-left effect
  - `.nsm-dialog-animation-ttb`: the modal comes with a top-to-bottom effect
  - `.nsm-dialog-animation-btt`: the modal comes with a bottom-to-top effect
- - `.nsm-centered`: the modal is centered vertical
+ - `.nsm-centered`: the modal is centered vertically
 
 
 ## Parameters / Options
@@ -172,7 +172,7 @@ The below documentation will use the following pattern:
 
 - `autostart` (boolean) | `false` ― _Define if the modal is showing up automatically when loaded or not._
 
-- `target` (string) | `undefined` ― _Displays the modal at the location of the target element
+- `target` (string) | `undefined` ― _Displays the modal relatively to the targeted element. ⚠️ Only for `NgxSmartModal >= 7.0.0`!_
 
 
 ## Manipulate modals
@@ -339,8 +339,25 @@ export class AppComponent {
 To get more details about the available methods, their parameters and what they return, please take a look at **[ngx-smart-modal.service.ts](https://github.com/biig-io/ngx-smart-modal/blob/master/src/ngx-smart-modal/src/services/ngx-smart-modal.service.ts)** file (well documented).
 
 
+## Precautions when upgrading to a newer version
+### Upgrade from <=5.x.x to 6.x.x
+Make sure that you imported `ngx-smart-modal.scss` or `ngx-smart-modal.css` in a global style file (e.g. `styles.scss` or `styles.css` in classic Angular projects or any other scss/css file it imports).
+
+### Upgrade from <=6.x.x to >=7.x.x
+Nothing should break unless if you added custom style to the modal content. In this case, it may break your existing style. To fix it, you simply have to add the `.nsm-body` selector after the `.nsm-dialog` selector because from now, the modal content is wrapped in a `.nsm-body` block.
+
+
 ## Author and Maintainer
 * [Maxime LAFARIE](https://github.com/maximelafarie)
+
+## Contributors
+* [Mark LUCAS](https://github.com/marco10024)
+* [gaetanmarsault](https://github.com/gaetanmarsault)
+* [neromaycry](https://github.com/neromaycry)
+* [Kraus Vincent](https://github.com/khylias)
+* [Andreas Bissinger](https://github.com/be-ndee)
+* [Yosbel Marín](https://github.com/yosbelms)
+* [Thomas Chang](https://github.com/thomascsd)
 
 
 ## Issues

--- a/src/ngx-smart-modal/package-lock.json
+++ b/src/ngx-smart-modal/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "ngx-smart-modal",
-  "version": "6.0.4",
+  "version": "7.0.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/src/ngx-smart-modal/package.json
+++ b/src/ngx-smart-modal/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ngx-smart-modal",
-  "version": "6.0.4",
+  "version": "7.0.0",
   "description": "Smart modal handler to manage modals and data everywhere in Angular apps.",
   "main": "./bundles/ngx-smart-modal.umd.js",
   "module": "./esm5/ngx-smart-modal.js",

--- a/src/ngx-smart-modal/src/components/ngx-smart-modal.component.ts
+++ b/src/ngx-smart-modal/src/components/ngx-smart-modal.component.ts
@@ -46,7 +46,7 @@ export class NgxSmartModalComponent implements OnInit, OnDestroy {
   @Input() public visible: boolean = false;
   @Input() public backdrop: boolean = true;
   @Input() public force: boolean = true;
-  @Input() public hideDelay: number = 200;
+  @Input() public hideDelay: number = 500;
   @Input() public autostart: boolean = false;
   @Input() public target: any;
 

--- a/src/ngx-smart-modal/src/ngx-smart-modal.scss
+++ b/src/ngx-smart-modal/src/ngx-smart-modal.scss
@@ -6,7 +6,7 @@ $dialog-position-top: 1.75rem !default;
 
 // Transition time
 // !! The same as the hideDelay variable defined in ngx-smart-modal.component.ts
-$transition-duration: 200ms !default;
+$transition-duration: 500ms !default;
 
 // Transition effect
 // linear | ease | ease-in | ease-out | ease-in-out


### PR DESCRIPTION
Fix regression on animation durations, improve readme by adding new options and a dedicated block
for upgrading the library to a newer version, and add new 7.0.0 version

BREAKING CHANGE: Potentially breaks custom style on modal content if not wrapped by `.nsm-body`
selector