### PR TITLE
Close All feature added

### DIFF
--- a/README.md
+++ b/README.md
@@ -335,6 +335,7 @@ export class AppComponent {
  - `getModalData(id: string)`: retrieve modal data by its identifier
  - `resetModalData(id: string)`: reset the data attached to a given modal
  - `closeLatestModal()`: Close the latest opened modal **if it has been declared as escapable**
+ - `closeAll()`: Close all opened modal without knowing their identifier
 
 To get more details about the available methods, their parameters and what they return, please take a look at **[ngx-smart-modal.service.ts](https://github.com/biig-io/ngx-smart-modal/blob/master/src/ngx-smart-modal/src/services/ngx-smart-modal.service.ts)** file (well documented).
 

--- a/src/ngx-smart-modal/src/services/ngx-smart-modal.service.ts
+++ b/src/ngx-smart-modal/src/services/ngx-smart-modal.service.ts
@@ -214,4 +214,14 @@ export class NgxSmartModalService {
   public closeLatestModal(): void {
     this.getTopOpenedModal().close();
   }
+
+  /**
+   * Close all opened modals without need of knowing their identifiers
+   */
+  public closeAll(): void {
+    let openModals = this.getOpenedModals();
+    openModals.forEach(function(item) {
+      item.modal.close();
+    });
+  }
 }

--- a/src/ngx-smart-modal/src/services/ngx-smart-modal.service.ts
+++ b/src/ngx-smart-modal/src/services/ngx-smart-modal.service.ts
@@ -219,9 +219,8 @@ export class NgxSmartModalService {
    * Close all opened modals without need of knowing their identifiers
    */
   public closeAll(): void {
-    let openModals = this.getOpenedModals();
-    openModals.forEach(function(item) {
-      item.modal.close();
+    this.getOpenedModals().forEach((instance: ModalInstance) => {
+      instance.modal.close();
     });
   }
 }

--- a/src/ngx-smart-modal/tests/services/ngx-smart-modal.service.spec.ts
+++ b/src/ngx-smart-modal/tests/services/ngx-smart-modal.service.spec.ts
@@ -369,4 +369,40 @@ describe('NgxSmartModalService', () => {
 
     expect(service.getTopOpenedModal).toHaveBeenCalled();
   }));
+
+  it('should closeAll', async(() => {
+    inject([NgxSmartModalService],
+      (ngxSmartModalService: NgxSmartModalService) => {
+        const firstFixture = TestBed.createComponent(NgxSmartModalComponent);
+        const secFixture = TestBed.createComponent(NgxSmartModalComponent);
+        const thirdFixture = TestBed.createComponent(NgxSmartModalComponent);
+        const firstApp = firstFixture.debugElement.componentInstance;
+        const secApp = secFixture.debugElement.componentInstance;
+        const thirdApp = thirdFixture.debugElement.componentInstance;
+        firstApp.identifier = 'myFirstModal';
+        secApp.identifier = 'mySecModal';
+        thirdApp.identifier = 'myThirdModal';
+
+        spyOn(ngxSmartModalService, 'closeAll').and.callThrough();
+        spyOn(ngxSmartModalService, 'getOpenedModals').and.callThrough();
+
+        ngxSmartModalService.getModal('myFirstModal').onOpen.subscribe(() => {
+          ngxSmartModalService.getModal('mySecModal').open();
+        })
+        ngxSmartModalService.getModal('mySecModal').onOpen.subscribe(() => {
+          ngxSmartModalService.getModal('myThirdModal').open();
+        })
+        ngxSmartModalService.getModal('myFirstModal').open();
+        expect(firstApp.visible).toBeTruthy();
+        expect(secApp.visible).toBeTruthy();
+        expect(thirdApp.visible).toBeTruthy();
+        ngxSmartModalService.closeAll();
+        tick();
+        expect(ngxSmartModalService.closeAll).toHaveBeenCalled();
+        expect(ngxSmartModalService.getOpenedModals).toHaveBeenCalled();
+        expect(firstApp.visible).toBeFalsy();
+        expect(secApp.visible).toBeFalsy();
+        expect(thirdApp.visible).toBeFalsy();
+      });
+  }));
 });


### PR DESCRIPTION
In some cases you just want to close any opened modal and you don't/want to know their identifiers. So there should be a function which could close them all specially when there are multiple modals opened on each other.
So I added a new function called closeAll() which would do this automatically in the service.