### PR TITLE
feat: Add refocus prop to prevent refocus after close

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3882,8 +3882,7 @@
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -3904,14 +3903,12 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -3926,20 +3923,17 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -4056,8 +4050,7 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "ini": {
           "version": "1.3.5",
@@ -4069,7 +4062,6 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -4084,7 +4076,6 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -4092,14 +4083,12 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "minipass": {
           "version": "2.3.5",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -4118,7 +4107,6 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -4199,8 +4187,7 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -4212,7 +4199,6 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -4298,8 +4284,7 @@
         "safe-buffer": {
           "version": "5.1.2",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -4335,7 +4320,6 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -4355,7 +4339,6 @@
           "version": "3.0.1",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -4399,14 +4382,12 @@
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "yallist": {
           "version": "3.0.3",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         }
       }
     },

--- a/src/app/doc/parts/options/options.component.ts
+++ b/src/app/doc/parts/options/options.component.ts
@@ -92,6 +92,12 @@ export class OptionsComponent implements OnInit {
       type: 'string',
       defaultValue: 'undefined',
       description: 'Define an accessible description for your modal. Enter the id of your description content.'
+    },
+    {
+      name: 'refocus',
+      type: 'boolean',
+      defaultValue: 'true',
+      description: 'Refocus on the last focused element after closing the modal.'
     }
   ];
   // tslint:enable:max-line-length

--- a/src/ngx-smart-modal/src/components/ngx-smart-modal.component.ts
+++ b/src/ngx-smart-modal/src/components/ngx-smart-modal.component.ts
@@ -75,6 +75,7 @@ export class NgxSmartModalComponent implements OnInit, OnDestroy, AfterViewInit 
   @Input() public ariaLabel: string | null = null;
   @Input() public ariaLabelledBy: string | null = null;
   @Input() public ariaDescribedBy: string | null = null;
+  @Input() public refocus: boolean = true;
 
   @Output() public visibleChange: EventEmitter<boolean> = new EventEmitter<boolean>();
   @Output() public onClose: EventEmitter<any> = new EventEmitter();

--- a/src/ngx-smart-modal/src/config/ngx-smart-modal.config.ts
+++ b/src/ngx-smart-modal/src/config/ngx-smart-modal.config.ts
@@ -16,4 +16,5 @@ export interface INgxSmartModalOptions {
     ariaLabel?: string;
     ariaLabelledBy?: string;
     ariaDescribedBy?: string;
+    refocus?: boolean;
 }

--- a/src/ngx-smart-modal/src/services/ngx-smart-modal.service.ts
+++ b/src/ngx-smart-modal/src/services/ngx-smart-modal.service.ts
@@ -255,6 +255,7 @@ export class NgxSmartModalService {
       if (typeof options.ariaLabel === 'string') { componentRef.instance.ariaLabel = options.ariaLabel; }
       if (typeof options.ariaLabelledBy === 'string') { componentRef.instance.ariaLabelledBy = options.ariaLabelledBy; }
       if (typeof options.ariaDescribedBy === 'string') { componentRef.instance.ariaDescribedBy = options.ariaDescribedBy; }
+      if (typeof options.refocus === 'boolean') { componentRef.instance.refocus = options.refocus; }
 
       this._appRef.attachView(componentRef.hostView);
 

--- a/src/ngx-smart-modal/src/services/ngx-smart-modal.service.ts
+++ b/src/ngx-smart-modal/src/services/ngx-smart-modal.service.ts
@@ -383,7 +383,9 @@ export class NgxSmartModalService {
       modal.markForCheck();
       modal.onCloseFinished.emit(modal);
       modal.onAnyCloseEventFinished.emit(modal);
-      this.lastElementFocused.focus();
+      if (modal.refocus) {
+        this.lastElementFocused.focus();
+      }
     }, modal.hideDelay);
 
     return true;

--- a/src/ngx-smart-modal/tests/services/ngx-smart-modal.service.spec.ts
+++ b/src/ngx-smart-modal/tests/services/ngx-smart-modal.service.spec.ts
@@ -354,6 +354,53 @@ describe('NgxSmartModalService', () => {
     service.create('test2', 'test content');
   }));
 
+  it('should refocus on close', fakeAsync(inject([NgxSmartModalService], (service: NgxSmartModalService) => {
+    const fixture = TestBed.createComponent(NgxSmartModalComponent);
+    const focusElement = fixture.nativeElement.appendChild(document.createElement('input'));
+    const app = fixture.debugElement.componentInstance;
+    app.identifier = 'test';
+    app.target = 'test-target';
+
+    service.addModal({ id: 'test', modal: app });
+    focusElement.focus();
+
+    expect(document.activeElement === focusElement).toBeTruthy();
+
+    service.open('test');
+    tick(501);
+
+    expect(document.activeElement === focusElement).toBeFalsy();
+
+    service.close('test');
+    tick(501);
+
+    expect(document.activeElement === focusElement).toBeTruthy();
+  })));
+
+  it('should not refocus on close if refocus is turned off', fakeAsync(inject([NgxSmartModalService], (service: NgxSmartModalService) => {
+    const fixture = TestBed.createComponent(NgxSmartModalComponent);
+    const focusElement = fixture.nativeElement.appendChild(document.createElement('input'));
+    const app = fixture.debugElement.componentInstance;
+    app.identifier = 'test';
+    app.target = 'test-target';
+    app.refocus = false;
+
+    service.addModal({ id: 'test', modal: app });
+    focusElement.focus();
+
+    expect(document.activeElement === focusElement).toBeTruthy();
+
+    service.open('test');
+    tick(501);
+
+    expect(document.activeElement === focusElement).toBeFalsy();
+
+    service.close('test');
+    tick(501);
+
+    expect(document.activeElement === focusElement).toBeFalsy();
+  })));
+
   it('should resolve content', inject([NgxSmartModalService], (service: NgxSmartModalService) => {
     (service as any)._resolveNgContent('test content');
     (service as any)._resolveNgContent(FakeComponent);


### PR DESCRIPTION
We have some instances where we do not want to refocus the last focused element when closing the modal as this causes some unexpected scroll jumping.

I have added a prop of `refocus` which can be set to `false` to prevent refocus of the last element focused.

Thanks! Let me know if you need any changes.